### PR TITLE
FIX: Updated nx graph construction

### DIFF
--- a/snore/snore.py
+++ b/snore/snore.py
@@ -106,7 +106,7 @@ class SNoRe:
 
         # Rank nodes
         pagerank_scores = nx.pagerank(
-            nx.from_scipy_sparse_matrix(network))
+            nx.from_scipy_sparse_array(network))
         ranked_features = np.argsort(
             [pagerank_scores[i] for i in range(len(pagerank_scores))])[::-1]
 


### PR DESCRIPTION
`from_scipy_sparse_matrix` is from a version of `networkx `that is no longer maintained:
[see here for details](https://networkx.org/documentation/networkx-1.10/reference/generated/networkx.convert_matrix.from_scipy_sparse_matrix.html).

Instead, one may want to consider `from_scipy_sparse_array`: [see here for details](https://networkx.org/documentation/stable/reference/generated/networkx.convert_matrix.from_scipy_sparse_array.html).